### PR TITLE
pyzstd_pep517: name config_settings argument correctly

### DIFF
--- a/build_script/pyzstd_pep517.py
+++ b/build_script/pyzstd_pep517.py
@@ -1,10 +1,10 @@
 from setuptools import build_meta as _orig
 from setuptools.build_meta import *
 
-def get_requires_for_build_wheel(cfg=None):
+def get_requires_for_build_wheel(config_settings=None):
     requires = []
-    if isinstance(cfg, dict) and '--build-option' in cfg:
-        v = cfg['--build-option']
+    if isinstance(config_settings, dict) and '--build-option' in config_settings:
+        v = config_settings['--build-option']
         if isinstance(v, (str, list)) and '--cffi' in v:
             requires.append('cffi')
-    return _orig.get_requires_for_build_wheel(cfg) + requires
+    return _orig.get_requires_for_build_wheel(config_settings) + requires


### PR DESCRIPTION
Ref: https://peps.python.org/pep-0517/#get-requires-for-build-wheel