### PR TITLE
Replace _PyLong_AsInt() with PyLong_AsInt() for Python 3.13+

### DIFF
--- a/src/bin_ext/file.c
+++ b/src/bin_ext/file.c
@@ -658,7 +658,7 @@ ZstdFileWriter_flush(ZstdFileWriter *self, PyObject *arg)
     STATE_FROM_OBJ(self);
 
     /* Mode argument */
-    mode = _PyLong_AsInt(arg);
+    mode = PyLong_AsInt(arg);
 
     assert(ZSTD_e_flush == 1 && ZSTD_e_end == 2);
     if (mode != ZSTD_e_flush && mode != ZSTD_e_end) {

--- a/src/bin_ext/macro_functions.h
+++ b/src/bin_ext/macro_functions.h
@@ -14,7 +14,7 @@ PYZSTD_FUN_PREFIX(set_c_parameters)(PYZSTD_C_CLASS *self, PyObject *level_or_opt
 
     /* Integer compression level */
     if (PyLong_Check(level_or_option)) {
-        const int level = _PyLong_AsInt(level_or_option);
+        const int level = PyLong_AsInt(level_or_option);
         if (level == -1 && PyErr_Occurred()) {
             PyErr_SetString(PyExc_ValueError,
                             "Compression level should be 32-bit signed int value.");
@@ -52,14 +52,14 @@ PYZSTD_FUN_PREFIX(set_c_parameters)(PYZSTD_C_CLASS *self, PyObject *level_or_opt
             }
 
             /* Both key & value should be 32-bit signed int */
-            const int key_v = _PyLong_AsInt(key);
+            const int key_v = PyLong_AsInt(key);
             if (key_v == -1 && PyErr_Occurred()) {
                 PyErr_SetString(PyExc_ValueError,
                                 "Key of option dict should be 32-bit signed int value.");
                 return -1;
             }
 
-            const int value_v = _PyLong_AsInt(value);
+            const int value_v = PyLong_AsInt(value);
             if (value_v == -1 && PyErr_Occurred()) {
                 PyErr_SetString(PyExc_ValueError,
                                 "Value of option dict should be 32-bit signed int value.");
@@ -125,7 +125,7 @@ PYZSTD_FUN_PREFIX(load_c_dict)(PYZSTD_C_CLASS *self, PyObject *dict)
             return -1;
         } else if (ret > 0) {
             /* type == -1 may indicate an error. */
-            type = _PyLong_AsInt(PyTuple_GET_ITEM(dict, 1));
+            type = PyLong_AsInt(PyTuple_GET_ITEM(dict, 1));
             if (type == DICT_TYPE_DIGESTED ||
                 type == DICT_TYPE_UNDIGESTED ||
                 type == DICT_TYPE_PREFIX)
@@ -206,14 +206,14 @@ PYZSTD_FUN_PREFIX(set_d_parameters)(PYZSTD_D_CLASS *self, PyObject *option)
         }
 
         /* Both key & value should be 32-bit signed int */
-        const int key_v = _PyLong_AsInt(key);
+        const int key_v = PyLong_AsInt(key);
         if (key_v == -1 && PyErr_Occurred()) {
             PyErr_SetString(PyExc_ValueError,
                             "Key of option dict should be 32-bit signed integer value.");
             return -1;
         }
 
-        const int value_v = _PyLong_AsInt(value);
+        const int value_v = PyLong_AsInt(value);
         if (value_v == -1 && PyErr_Occurred()) {
             PyErr_SetString(PyExc_ValueError,
                             "Value of option dict should be 32-bit signed integer value.");
@@ -261,7 +261,7 @@ PYZSTD_FUN_PREFIX(load_d_dict)(PYZSTD_D_CLASS *self, PyObject *dict)
             return -1;
         } else if (ret > 0) {
             /* type == -1 may indicate an error. */
-            type = _PyLong_AsInt(PyTuple_GET_ITEM(dict, 1));
+            type = PyLong_AsInt(PyTuple_GET_ITEM(dict, 1));
             if (type == DICT_TYPE_DIGESTED ||
                 type == DICT_TYPE_UNDIGESTED ||
                 type == DICT_TYPE_PREFIX)

--- a/src/bin_ext/pyzstd.h
+++ b/src/bin_ext/pyzstd.h
@@ -21,6 +21,11 @@
     #define Py_UNREACHABLE() assert(0)
 #endif
 
+/* Added in Python 3.13 */
+#if PY_VERSION_HEX < 0x030D00A1
+    #define PyLong_AsInt _PyLong_AsInt
+#endif
+
 /* Multi-phase init (PEP-489) */
 #if PY_VERSION_HEX < 0x030B00B1 && defined(USE_MULTI_PHASE_INIT)
     /* PyType_GetModuleByDef() function is available on CPython 3.11+.


### PR DESCRIPTION
The new public function `PyLong_AsInt()` has been introduced as part of https://github.com/python/cpython/issues/108444, which renames the internal `_PyLong_AsInt()` to `PyLong_AsInt()`. This change updates the code to use the new public API while maintaining compatibility with Python versions earlier than 3.13.

Fixes #13