### PR TITLE
Fix typos in strings

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1128,7 +1128,7 @@ Advanced parameters
 
      .. py:attribute:: targetCBlockSize
 
-        Attempts to fit compressed block size into approximatively targetCBlockSize (in bytes). Note that it's not a guarantee, just a convergence target.
+        Attempts to fit compressed block size into approximately targetCBlockSize (in bytes). Note that it's not a guarantee, just a convergence target.
 
         This is helpful in low bandwidth streaming environments to improve end-to-end latency, when a client can make use of partial documents.
 

--- a/src/bin_ext/pyzstd.c
+++ b/src/bin_ext/pyzstd.c
@@ -90,7 +90,7 @@ success:
 }
 
 PyDoc_STRVAR(_get_frame_info_doc,
-"Internal function, get zstd frame infomation from a frame header.");
+"Internal function, get zstd frame information from a frame header.");
 
 static PyObject *
 _get_frame_info(PyObject *module, PyObject *args)

--- a/src/bin_ext/pyzstd.h
+++ b/src/bin_ext/pyzstd.h
@@ -66,7 +66,7 @@ typedef struct {
     /* Thread lock for generating ZSTD_CDict/ZSTD_DDict */
     PyThread_type_lock lock;
 
-    /* Reuseable compress/decompress dictionary, they are created once and
+    /* Reusable compress/decompress dictionary, they are created once and
        can be shared by multiple threads concurrently, since its usage is
        read-only.
        c_dicts is a dict, int(compressionLevel):PyCapsule(ZSTD_CDict*) */

--- a/src/c/__init__.py
+++ b/src/c/__init__.py
@@ -34,7 +34,7 @@ _nt_frame_info = namedtuple('frame_info',
                             ['decompressed_size', 'dictionary_id'])
 
 def get_frame_info(frame_buffer):
-    """Get zstd frame infomation from a frame header.
+    """Get zstd frame information from a frame header.
 
     Parameter
     frame_buffer: A bytes-like object. It should starts from the beginning of

--- a/tests/test_zstd.py
+++ b/tests/test_zstd.py
@@ -1715,8 +1715,8 @@ class DecompressorFlagsTestCase(unittest.TestCase):
         with self.assertRaises(ZstdError):
             d.decompress(self.FRAME_42 + self.TRAIL)
 
-        self.assertTrue(d.at_frame_edge) # resetted
-        self.assertTrue(d.needs_input)   # resetted
+        self.assertTrue(d.at_frame_edge) # has been reset
+        self.assertTrue(d.needs_input)   # has been reset
 
         # 2 frames, a
         d = EndlessZstdDecompressor()
@@ -2104,7 +2104,7 @@ class ZstdDictTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             _zstd._finalize_dict(TRAINED_DICT.dict_content, b'', [], 0, 5)
 
-    def test_train_buffer_protocal_samples(self):
+    def test_train_buffer_protocol_samples(self):
         def _nbytes(dat):
             if isinstance(dat, (bytes, bytearray)):
                 return len(dat)
@@ -2379,9 +2379,9 @@ class OutputBufferTestCase(unittest.TestCase):
         # 2 frame, the second frame's decompressed size is unknown
         for extra in [-1, 0, 1]:
             SIZE2 = self.BLOCK_SIZE[1] + self.BLOCK_SIZE[2] + extra
-            unkown_size = self.compress_unknown_size(SIZE2)
+            unknown_size = self.compress_unknown_size(SIZE2)
 
-            dat = decompress(known_size + unkown_size)
+            dat = decompress(known_size + unknown_size)
             self.assertEqual(len(dat), SIZE1 + SIZE2)
 
     # def test_large_output(self):


### PR DESCRIPTION
Typos found with https://github.com/crate-ci/typos

Closes #16 