### PR TITLE
Support for PyPy 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ env:
   PYTHON_VER: "3.11" # Python to run test/cibuildwheel
   CIBW_BUILD: >
     cp39-* cp310-* cp311-* cp312-* cp313-*
-    pp39-* pp310-*
+    pp39-* pp310-* pp311-*
   CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
 
 jobs:
@@ -92,6 +92,7 @@ jobs:
         py:
           - "pypy-3.9"
           - "pypy-3.10"
+          - "pypy-3.11"
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Support for PyPy 3.11
+
 ## 0.16.2 (October 10, 2024)
 
 - Build wheels for Python 3.13


### PR DESCRIPTION
- Run test in CI on PyPy 3.11
- Build wheels for PyPy 3.11

:warning: currently blocked until the next release of `cibuildwheel`