### PR TITLE
fix: use @lru_cache decorator on a function outside class

### DIFF
--- a/src/c/__init__.py
+++ b/src/c/__init__.py
@@ -54,6 +54,9 @@ def get_frame_info(frame_buffer):
     ret_tuple = _zstd._get_frame_info(frame_buffer)
     return _nt_frame_info(*ret_tuple)
 
+@lru_cache(maxsize=None)
+def _get_param_bounds(zstd_param, zstd_param_val):
+    return _zstd._get_param_bounds(zstd_param, zstd_param_val)
 
 class _UnsupportedCParameter:
     def __set_name__(self, _, name):
@@ -97,11 +100,10 @@ class CParameter(IntEnum):
     jobSize                    = _zstd._ZSTD_c_jobSize
     overlapLog                 = _zstd._ZSTD_c_overlapLog
 
-    @lru_cache(maxsize=None)
     def bounds(self):
         """Return lower and upper bounds of a compression parameter, both inclusive."""
         # 1 means compression parameter
-        return _zstd._get_param_bounds(1, self.value)
+        return _get_param_bounds(1, self.value)
 
 
 class DParameter(IntEnum):
@@ -109,11 +111,10 @@ class DParameter(IntEnum):
 
     windowLogMax = _zstd._ZSTD_d_windowLogMax
 
-    @lru_cache(maxsize=None)
     def bounds(self):
         """Return lower and upper bounds of a decompression parameter, both inclusive."""
         # 0 means decompression parameter
-        return _zstd._get_param_bounds(0, self.value)
+        return _get_param_bounds(0, self.value)
 
 
 class Strategy(IntEnum):

--- a/src/cffi/common.py
+++ b/src/cffi/common.py
@@ -31,6 +31,7 @@ class ZstdError(Exception):
     "Call to the underlying zstd library failed."
     pass
 
+@lru_cache(maxsize=None)
 def _get_param_bounds(is_compress, key):
     # Get parameter bounds
     if is_compress:
@@ -87,7 +88,6 @@ class CParameter(IntEnum):
     jobSize                    = m.ZSTD_c_jobSize
     overlapLog                 = m.ZSTD_c_overlapLog
 
-    @lru_cache(maxsize=None)
     def bounds(self):
         """Return lower and upper bounds of a compression parameter, both inclusive."""
         # 1 means compression parameter
@@ -98,7 +98,6 @@ class DParameter(IntEnum):
 
     windowLogMax = m.ZSTD_d_windowLogMax
 
-    @lru_cache(maxsize=None)
     def bounds(self):
         """Return lower and upper bounds of a decompression parameter, both inclusive."""
         # 0 means decompression parameter


### PR DESCRIPTION
This pull request refactors the `bounds` instance methods to call an external funcction that's decorated with `lru_cache` to avoid memory leaks. For a bit more detail, see https://docs.astral.sh/ruff/rules/cached-instance-method/
