### PR TITLE
Build wheels for Windows ARM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,6 +148,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+          - windows-11-arm
 
     env:
       CIBW_ARCHS_MACOS: "x86_64 arm64"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Upgrade zstd source code from v1.5.6 to [v1.5.7](https://github.com/facebook/zstd/releases/tag/v1.5.7)
+- Build wheels for Windows ARM64
 - Support for PyPy 3.11
 
 ## 0.16.2 (October 10, 2024)


### PR DESCRIPTION
Adding a new runner (instead of reusing Windows one) since [cibuildwheels does not support testing Windows ARM wheels built in cross-compilation](https://cibuildwheel.pypa.io/en/stable/faq/#windows-arm64).

Closes #33.