### PR TITLE
Raise an exception when attempting to decompressing empty data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Upgrade zstd source code from v1.5.6 to [v1.5.7](https://github.com/facebook/zstd/releases/tag/v1.5.7)
+- Raise an exception when attempting to decompress empty data
 - Build wheels for Windows ARM64
 - Support for PyPy 3.11
 

--- a/src/bin_ext/decompressor.c
+++ b/src/bin_ext/decompressor.c
@@ -825,7 +825,7 @@ decompress(PyObject *module, PyObject *args, PyObject *kwargs)
 
     /* Check data integrity. at_frame_edge flag is 1 when both the input and
        output streams are at a frame edge. */
-    if (self.at_frame_edge == 0) {
+    if (self.at_frame_edge == 0 || in.pos == 0) {
         char *extra_msg = (Py_SIZE(ret) == 0) ? "." :
                           ", if want to output these decompressed data, use "
                           "decompress_stream function or "

--- a/src/cffi/decompressor.py
+++ b/src/cffi/decompressor.py
@@ -401,7 +401,7 @@ def decompress(data, zstd_dict=None, option=None):
 
     # Check data integrity. at_frame_edge flag is True when the both the input
     # and output streams are at a frame edge.
-    if not decomp._at_frame_edge:
+    if not decomp._at_frame_edge or not in_buf.pos:
         extra_msg = "." if (len(ret) == 0) \
                         else (", if want to output these decompressed data, use "
                               "decompress_stream function or "

--- a/tests/test_seekable.py
+++ b/tests/test_seekable.py
@@ -845,7 +845,8 @@ class SeekableZstdFileCase(unittest.TestCase):
         # empty
         b = BytesIO()
         with SeekableZstdFile(b, 'r') as f:
-            self.assertEqual(f.read(10), b'')
+            with self.assertRaises(EOFError):
+                f.read(10)
 
         # not a seekable format
         b = BytesIO(COMPRESSED*10)
@@ -882,15 +883,8 @@ class SeekableZstdFileCase(unittest.TestCase):
 
     def test_read_empty(self):
         with SeekableZstdFile(BytesIO(b''), 'r') as f:
-            self.assertEqual(f.read(), b'')
-            self.assertEqual(f.tell(), 0)
-
-            self.assertEqual(f.seek(2), 0)
-            self.assertEqual(f.read(), b'')
-            self.assertEqual(f.tell(), 0)
-
-            self.assertEqual(f.seek(-2), 0)
-            self.assertEqual(f.read(), b'')
+            with self.assertRaises(EOFError):
+                f.read()
             self.assertEqual(f.tell(), 0)
 
     def test_seek(self):

--- a/tests/test_zstd.py
+++ b/tests/test_zstd.py
@@ -1229,7 +1229,8 @@ class CompressorDecompressorTestCase(unittest.TestCase):
         bo.close()
 
     def test_decompress_empty(self):
-        self.assertEqual(decompress(b''), b'')
+        with self.assertRaises(ZstdError):
+            decompress(b'')
 
         d = ZstdDecompressor()
         self.assertEqual(d.decompress(b''), b'')
@@ -1325,7 +1326,8 @@ class DecompressorFlagsTestCase(unittest.TestCase):
         cls.TRAIL = b'12345678abcdefg!@#$%^&*()_+|'
 
     def test_function_decompress(self):
-        self.assertEqual(decompress(b''), b'')
+        with self.assertRaises(ZstdError):
+            decompress(b'')
 
         self.assertEqual(len(decompress(COMPRESSED_100_PLUS_32KB)), 100+32*1024)
 
@@ -2234,8 +2236,8 @@ class OutputBufferTestCase(unittest.TestCase):
         dat1 = b''
 
         # decompress() function
-        dat2 = decompress(dat1)
-        self.assertEqual(len(dat2), 0)
+        with self.assertRaises(ZstdError):
+            decompress(dat1)
 
         # ZstdDecompressor class
         d = ZstdDecompressor()
@@ -2880,10 +2882,12 @@ class FileTestCase(unittest.TestCase):
         # empty file
         with ZstdFile(BytesIO(b'')) as f:
             self.assertEqual(f.read(0), b"")
-            self.assertEqual(f.read(10), b"")
+            with self.assertRaises(EOFError):
+                f.read(10)
 
         with ZstdFile(BytesIO(b'')) as f:
-            self.assertEqual(f.read(10), b"")
+            with self.assertRaises(EOFError):
+                f.read(10)
 
     def test_read_10(self):
         with ZstdFile(BytesIO(COMPRESSED_100_PLUS_32KB)) as f:
@@ -3517,8 +3521,9 @@ class OpenTestCase(unittest.TestCase):
     def test_text_modes(self):
         # empty input
         with open(BytesIO(b''), "rt", encoding="utf-8", newline='\n') as reader:
-            for _ in reader:
-                pass
+            with self.assertRaises(EOFError):
+                for _ in reader:
+                    pass
 
         # read
         uncompressed = THIS_FILE_STR.replace(os.linesep, "\n")


### PR DESCRIPTION
From [Zstandard specification](https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md#frames):

> Zstandard compressed data is made of one or more frames.

Currently, we allow to decompress empty data:
```py
>>> decompress(b"")
b''
```

After the fix, this is not allowed anymore:
```py
>>> decompress(b"")
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    decompress(b"")
    ~~~~~~~~~~^^^^^
pyzstd.ZstdError: Decompression failed: zstd data ends in an incomplete frame, maybe the input data was truncated. Decompressed data is 0 bytes.
```