### PR TITLE
Remove caching on CParameter.bounds & DParameter.bounds

### DIFF
--- a/src/_c/__init__.py
+++ b/src/_c/__init__.py
@@ -1,6 +1,5 @@
 from collections import namedtuple
 from enum import IntEnum
-from functools import lru_cache
 
 from ._zstd import (
     EndlessZstdDecompressor,
@@ -145,7 +144,6 @@ class CParameter(IntEnum):
     jobSize                    = _ZSTD_c_jobSize
     overlapLog                 = _ZSTD_c_overlapLog
 
-    @lru_cache(maxsize=None)
     def bounds(self):
         """Return lower and upper bounds of a compression parameter, both inclusive."""
         # 1 means compression parameter
@@ -157,7 +155,6 @@ class DParameter(IntEnum):
 
     windowLogMax = _ZSTD_d_windowLogMax
 
-    @lru_cache(maxsize=None)
     def bounds(self):
         """Return lower and upper bounds of a decompression parameter, both inclusive."""
         # 0 means decompression parameter

--- a/src/_cffi/common.py
+++ b/src/_cffi/common.py
@@ -1,7 +1,6 @@
 import sys
 from collections import namedtuple
 from enum import IntEnum
-from functools import lru_cache
 
 from ._cffi_zstd import ffi, lib as m
 
@@ -87,7 +86,6 @@ class CParameter(IntEnum):
     jobSize                    = m.ZSTD_c_jobSize
     overlapLog                 = m.ZSTD_c_overlapLog
 
-    @lru_cache(maxsize=None)
     def bounds(self):
         """Return lower and upper bounds of a compression parameter, both inclusive."""
         # 1 means compression parameter
@@ -98,7 +96,6 @@ class DParameter(IntEnum):
 
     windowLogMax = m.ZSTD_d_windowLogMax
 
-    @lru_cache(maxsize=None)
     def bounds(self):
         """Return lower and upper bounds of a decompression parameter, both inclusive."""
         # 0 means decompression parameter

--- a/tests/test_zstd.py
+++ b/tests/test_zstd.py
@@ -1297,19 +1297,6 @@ class CompressorDecompressorTestCase(unittest.TestCase):
         self.assertFalse(d.at_frame_edge)
         self.assertTrue(d.needs_input)
 
-    def test_parameter_bounds_cache(self):
-        a = CParameter.compressionLevel.bounds()
-        b = CParameter.compressionLevel.bounds()
-        self.assertIs(a, b)
-
-        a = CParameter.windowLog.bounds()
-        b = CParameter.windowLog.bounds()
-        self.assertIs(a, b)
-
-        a = DParameter.windowLogMax.bounds()
-        b = DParameter.windowLogMax.bounds()
-        self.assertIs(a, b)
-
 class DecompressorFlagsTestCase(unittest.TestCase):
 
     @classmethod


### PR DESCRIPTION
They look like premature optimization, and can be reported by tooling as memory leak (e.g. [ruff B019](https://docs.astral.sh/ruff/rules/cached-instance-method/), #30).