### PR TITLE
Deprecate rich apis and read_size/write_size params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Deprecate the `read_size` and `write_size` parameters of `ZstdFile` and `SeekableZstdFile`
+- Deprecate `richmem_compress` and `RichMemZstdCompressor`
 - Rework documentation to suggest using `compression.zstd` from Python stdlib, and provide a migration guide
 - Include the `zstd` library license in package distributions
 

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -19,6 +19,20 @@ Instead of the `read_size` and `write_size` parameters, you can use
 `shutil.copyfileobj`'s `length` parameter.
 ```
 
+Alternatively, you can use `ZstdCompressor` to have more control:
+
+```python
+# after: more complex alternative
+with io.open(input_file_path, 'rb') as ifh:
+    with io.open(output_file_path, 'wb') as ofh:
+        compressor = ZstdCompressor(level_or_option=5)
+        compressor._set_pledged_input_size(pledged_input_size)  # optional
+        while data := ifh.read(read_size):
+            ofh.write(compressor.compress(data))
+            callback_progress(ifh.tell(), ofh.tell())  # optional
+        ofh.write(compressor.flush())
+```
+
 _Deprecated in version 0.17.0._
 
 ## `decompress_stream`
@@ -40,4 +54,53 @@ Instead of the `read_size` and `write_size` parameters, you can use
 `shutil.copyfileobj`'s `length` parameter.
 ```
 
+Alternatively, you can use `EndlessZstdDecompressor` to have more control:
+
+```python
+# after: more complex alternative
+with io.open(input_file_path, 'rb') as ifh:
+    with io.open(output_file_path, 'wb') as ofh:
+        decompressor = EndlessZstdDecompressor()
+        while True:
+            if decompressor.needs_input:
+                data = input_stream.read(read_size)
+                if not data:
+                    break
+            else:
+                data = b""
+            ofh.write(decompressor.decompress(data, write_size))
+            callback_progress(ifh.tell(), ofh.tell())  # optional
+        if not decompressor.at_frame_edge:
+            raise ValueError("zstd data ends in an incomplete frame")
+```
+
 _Deprecated in version 0.17.0._
+
+## `richmem_compress`
+
+```python
+# before
+data_out = pyzstd.richmem_compress(data_in, level_or_option=5)
+
+# after
+data_out = pyzstd.compress(data_in, level_or_option=5)
+```
+
+_Deprecated in version 0.18.0._
+
+## `RichMemZstdCompressor`
+
+```python
+# before
+compressor = pyzstd.RichMemZstdCompressor(level_or_option=5)
+data_out1 = compressor.compress(data_in1)
+data_out2 = compressor.compress(data_in2)
+data_out3 = compressor.compress(data_in3)
+
+# after
+data_out1 = pyzstd.compress(data_in1, level_or_option=5)
+data_out2 = pyzstd.compress(data_in2, level_or_option=5)
+data_out3 = pyzstd.compress(data_in3, level_or_option=5)
+```
+
+_Deprecated in version 0.18.0._

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -76,9 +76,9 @@ Here are possible alternatives:
 
 ## `RichMemZstdCompressor` and `richmem_compress`
 
-The `RichMemZstdCompressor` class and `richmem_compress` function are not available.
+The `RichMemZstdCompressor` class and `richmem_compress` function, which are deprecated in `pyzstd`, are not available.
 
-Use `ZstdCompressor` and `compress` instead.
+Use `compress` instead ([more details](./deprecated.md#richmem-compress)).
 
 ## `compress_stream` and `decompress_stream`
 
@@ -92,6 +92,38 @@ The constant `compressionLevel_values` namedtuple is not available. Use the foll
 
 - `zstd.COMPRESSION_LEVEL_DEFAULT` for the default compression level.
 - `zstd.CompressionParameter.compression_level.bounds()` for the minimum and maximum compression levels.
+
+## Exceptions raised
+
+The messages of raised exceptions are not always the same.
+
+When they are due to an error in the parameters used by the caller, the type of exceptions may change as well.
+
+```python
+# before
+>>> pyzstd.compress(b'', {999:9999})
+pyzstd.ZstdError: Zstd compression parameter "unknown parameter (key 999)" is invalid. (zstd v1.5.7)
+
+# after
+>>> zstd.compress(b'', options={999:9999})
+ValueError: invalid compression parameter 'unknown parameter (key 999)'
+```
+
+## `ZstdFile`
+
+The `read_size` and `write_size` parameters of `ZstdFile` are not available.
+
+## `ZstdDict`
+
+The `is_raw` parameter of `ZstdDict` is no longer positional. Call it by its name instead.
+
+```python
+# before
+pyzstd.ZstdDict(data, True)
+
+# after
+zstd.ZstdDict(data, is_raw=True)
+```
 
 ## `SeekableZstdFile`
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -5,7 +5,7 @@ try:
         DParameter,
         EndlessZstdDecompressor,
         PYZSTD_CONFIG,
-        RichMemZstdCompressor,
+        RichMemZstdCompressor as _RichMemZstdCompressor,
         Strategy,
         ZstdCompressor,
         ZstdDecompressor,
@@ -34,7 +34,7 @@ except ImportError:
             DParameter,
             EndlessZstdDecompressor,
             PYZSTD_CONFIG,
-            RichMemZstdCompressor,
+            RichMemZstdCompressor as _RichMemZstdCompressor,
             Strategy,
             ZstdCompressor,
             ZstdDecompressor,
@@ -118,6 +118,7 @@ def compress(data, level_or_option=None, zstd_dict=None):
     return comp.compress(data, ZstdCompressor.FLUSH_FRAME)
 
 
+@deprecated("See https://pyzstd.readthedocs.io/en/stable/deprecated.html for alternatives to pyzstd.richmem_compress")
 def richmem_compress(data, level_or_option=None, zstd_dict=None):
     """Compress a block of data, return a bytes object.
 
@@ -133,7 +134,7 @@ def richmem_compress(data, level_or_option=None, zstd_dict=None):
                      parameters.
     zstd_dict:       A ZstdDict object, pre-trained dictionary for compression.
     """
-    comp = RichMemZstdCompressor(level_or_option, zstd_dict)
+    comp = _RichMemZstdCompressor(level_or_option, zstd_dict)
     return comp.compress(data)
 
 
@@ -242,3 +243,9 @@ def compress_stream(*args, **kwargs):
 @deprecated("See https://pyzstd.readthedocs.io/en/stable/deprecated.html for alternatives to pyzstd.decompress_stream")
 def decompress_stream(*args, **kwargs):
     return _decompress_stream(*args, **kwargs)
+
+@deprecated("See https://pyzstd.readthedocs.io/en/stable/deprecated.html for alternatives to pyzstd.RichMemZstdCompressor")
+class RichMemZstdCompressor(_RichMemZstdCompressor):
+    pass
+
+RichMemZstdCompressor.__doc__ = _RichMemZstdCompressor.__doc__

--- a/src/__init__.pyi
+++ b/src/__init__.pyi
@@ -100,6 +100,7 @@ class ZstdCompressor:
 
     def _set_pledged_input_size(self, size: Union[int, None]) -> None: ...
 
+@deprecated("See https://pyzstd.readthedocs.io/en/stable/deprecated.html for alternatives to pyzstd.RichMemZstdCompressor")
 class RichMemZstdCompressor:
     def __init__(self,
                  level_or_option: Union[None, int, Dict[CParameter, int]] = None,
@@ -143,6 +144,7 @@ def compress(data,
              level_or_option: Union[None, int, Dict[CParameter, int]] = None,
              zstd_dict: Union[None, ZstdDict, ZstdDictInfo] = None) -> bytes: ...
 
+@deprecated("See https://pyzstd.readthedocs.io/en/stable/deprecated.html for alternatives to pyzstd.richmem_compress")
 def richmem_compress(data,
                      level_or_option: Union[None, int, Dict[CParameter, int]] = None,
                      zstd_dict: Union[None, ZstdDict, ZstdDictInfo] = None) -> bytes: ...

--- a/src/_seekable_zstdfile.py
+++ b/src/_seekable_zstdfile.py
@@ -6,7 +6,7 @@ from warnings import warn
 
 from pyzstd._zstdfile import _ZstdDecompressReader, ZstdFile, \
                             _MODE_CLOSED, _MODE_READ, _MODE_WRITE, \
-                            PathLike, io
+                            PathLike, io, _DEPRECATED_PLACEHOLDER
 
 __all__ = ('SeekableFormatError', 'SeekableZstdFile')
 
@@ -397,7 +397,7 @@ class SeekableZstdFile(ZstdFile):
 
     def __init__(self, filename, mode="r", *,
                  level_or_option=None, zstd_dict=None,
-                 read_size=131075, write_size=131591,
+                 read_size=_DEPRECATED_PLACEHOLDER, write_size=_DEPRECATED_PLACEHOLDER,
                  max_frame_content_size=1024*1024*1024):
         """Open a Zstandard Seekable Format file in binary mode. In read mode,
         the file can be 0-size file.
@@ -421,13 +421,6 @@ class SeekableZstdFile(ZstdFile):
             support int type compression level in this case.
         zstd_dict: A ZstdDict object, pre-trained dictionary for compression /
             decompression.
-        read_size: In reading mode, this is bytes number that read from the
-            underlying file object each time, default value is zstd's
-            recommended value. If use with Network File System, increasing
-            it may get better performance.
-        write_size: In writing modes, this is output buffer's size, default
-            value is zstd's recommended value. If use with Network File
-            System, increasing it may get better performance.
         max_frame_content_size: In write/append modes (compression), when
             the uncompressed data size reaches max_frame_content_size, a frame
             is generated automatically. If the size is small, it will increase

--- a/src/_zstdfile.py
+++ b/src/_zstdfile.py
@@ -1,4 +1,5 @@
 import io
+import warnings
 try:
     from os import PathLike
 except ImportError:
@@ -74,6 +75,11 @@ _MODE_CLOSED = 0
 _MODE_READ   = 1
 _MODE_WRITE  = 2
 
+class _DeprecatedPlaceholder:
+    def __repr__(self):
+        return '<DEPRECATED>'
+_DEPRECATED_PLACEHOLDER = _DeprecatedPlaceholder()
+
 class ZstdFile(io.BufferedIOBase):
     """A file object providing transparent zstd (de)compression.
 
@@ -91,7 +97,7 @@ class ZstdFile(io.BufferedIOBase):
 
     def __init__(self, filename, mode="r", *,
                  level_or_option=None, zstd_dict=None,
-                 read_size=131075, write_size=131591):
+                 read_size=_DEPRECATED_PLACEHOLDER, write_size=_DEPRECATED_PLACEHOLDER):
         """Open a zstd compressed file in binary mode.
 
         filename can be either an actual file name (given as a str, bytes, or
@@ -110,14 +116,16 @@ class ZstdFile(io.BufferedIOBase):
             support int type compression level in this case.
         zstd_dict: A ZstdDict object, pre-trained dictionary for compression /
             decompression.
-        read_size: In reading mode, this is bytes number that read from the
-            underlying file object each time, default value is zstd's
-            recommended value. If use with Network File System, increasing
-            it may get better performance.
-        write_size: In writing modes, this is output buffer's size, default
-            value is zstd's recommended value. If use with Network File
-            System, increasing it may get better performance.
         """
+        if read_size == _DEPRECATED_PLACEHOLDER:
+            read_size = 131075
+        else:
+            warnings.warn("pyzstd.ZstdFile()'s read_size parameter is deprecated", DeprecationWarning, stacklevel=2)
+        if write_size == _DEPRECATED_PLACEHOLDER:
+            write_size = 131591
+        else:
+            warnings.warn("pyzstd.ZstdFile()'s write_size parameter is deprecated", DeprecationWarning, stacklevel=2)
+
         self._fp = None
         self._closefp = False
         self._mode = _MODE_CLOSED


### PR DESCRIPTION
 - New deprecations:
   - `RichMemZstdCompressor` and `richmem_compress`
   - The `read_size` and `write_size` of the constructors of `ZstdFile` and `SeekableZstdFile`
 - Documentation:
   - Provides alternatives to new deprecations
   - Improve alternatives for `compress_stream` and `decompress_stream`
   - Add more differences between `pyzstd` and `compression.zstd`