### PR TITLE
ci: add support for riscv64 architecture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,6 +187,7 @@ jobs:
         arch:
           - aarch64
           - ppc64le
+          - riscv64
           - s390x
         # Building in QEMU is very slow, so parallelize the tasks.
         skip_image:


### PR DESCRIPTION
Now that cibuildwheel and PyPI both support riscv64, we can start building riscv64 wheels.

FYI, [RISE](https://riseproject.dev/) has been building, testing and distributing pyzstd for riscv64 (versions 0.17.0 and 0.18.0). Tested builds are available for riscv64 [here](https://riseproject.gitlab.io/python/wheel_builder/packages/pyzstd.html).