### PR TITLE
Skip failed test on 32bit platform

### DIFF
--- a/tests/test_seekable.py
+++ b/tests/test_seekable.py
@@ -12,6 +12,7 @@ import warnings
 
 from io import BytesIO
 from math import ceil
+from sysconfig import get_config_var
 from unittest.mock import patch
 
 from pyzstd import (
@@ -539,6 +540,7 @@ class SeekTableCase(unittest.TestCase):
                                     'cumulated compressed size'):
             t.load_seek_table(b, seek_to_0=True)
 
+    @unittest.skipIf(get_config_var('SIZEOF_SIZE_T') == 4, 'skip in 32-bit build')
     def test_write_table(self):
         class MockError(Exception):
             pass


### PR DESCRIPTION
Skip `write_table` test in 32 bit build.

```
OverflowError: cannot fit 'int' into an index-sized integer
```