### PR TITLE
Fix SeekableZstdFile write table on on 32bits architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Fix `SeekableZstdFile` write table entries on 32-bits architectures when there is a huge number of entries
+
 ## 0.19.0 (November 7, 2025)
 
 - The project has been completely refactored to use the Zstandard implementation from the standard library ([PEP-784](https://peps.python.org/pep-0784/))

--- a/src/pyzstd/_seekable_zstdfile.py
+++ b/src/pyzstd/_seekable_zstdfile.py
@@ -305,8 +305,9 @@ class _SeekTable:
         self._s_2uint32.pack_into(ba, offset, 0x184D2A5E, size - 8)
         offset += 8
         # Entries
-        for i in range(0, len(self._frames), 2):
-            self._s_2uint32.pack_into(ba, offset, self._frames[i], self._frames[i + 1])
+        iter_frames = iter(self._frames)
+        for frame_c, frame_d in zip(iter_frames, iter_frames, strict=True):
+            self._s_2uint32.pack_into(ba, offset, frame_c, frame_d)
             offset += 8
         # Footer
         self._s_footer.pack_into(ba, offset, self._frames_count, 0, 0x8F92EAB1)


### PR DESCRIPTION
As `len(self._frames)` raises an `OverflowError`, re-write this code part based on iterators to avoid the overflow.

Closes #61